### PR TITLE
Switch to Tasks + Task

### DIFF
--- a/src/Build/Task.hs
+++ b/src/Build/Task.hs
@@ -1,52 +1,40 @@
-{-# LANGUAGE ConstraintKinds, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE ConstraintKinds, RankNTypes #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
-module Build.Task (
-    Task, inputTask, isInput, compose, fetchIO, sprsh1, sprsh2, sprsh3
-    ) where
+module Build.Task (Task (..), Tasks, compose, fetchIO, sprsh1, sprsh2, sprsh3) where
 
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Fail (MonadFail)
-import Control.Monad.Reader
-import Data.Maybe
-import Data.Proxy
 
 -- | Task a value corresponding to a given key by performing necessary
 -- lookups of the dependencies using the provided lookup function. Returns
 -- @Nothing@ to indicate that a given key is an input.
-type Task c k v = forall f. c f => (k -> f v) -> k -> Maybe (f v)
+type Tasks c k v = k -> Maybe (Task c k v)
 
--- | The trivial task that considers all keys as inputs.
-inputTask :: (k -> f v) -> k -> Maybe (f v)
-inputTask _ _ = Nothing
+newtype Task c k v = Task { run :: forall f. c f => (k -> f v) -> f v }
 
--- TODO: How do we express this in terms of Task? Drop forall in Task?
--- isInput :: Task MonadPlus k v -> k -> Bool
-isInput :: ((k -> Proxy v) -> k -> Maybe (Proxy v)) -> k -> Bool
-isInput task = isNothing . task (const Proxy)
+compose :: Tasks Monad k v -> Tasks Monad k v -> Tasks Monad k v
+compose t1 t2 key = t1 key <|> t2 key
 
-compose :: Task Monad k v -> Task Monad k v -> Task Monad k v
-compose t1 t2 fetch key = t1 fetch key <|> t2 fetch key
+-- compose2 :: Tasks Monad k v -> Tasks Monad k v -> Tasks Monad k v
+-- compose2 t1 t2 fetch key = t1 fetch key <|> t2 fetch key
 
-type Task2 c k v = forall f. c f => k -> Maybe ((k -> f v) -> f v)
+-- type Tasks2 c k v = forall f. c f => (k -> f v) -> k -> Maybe (f v)
 
-toTask :: Task2 Monad k v -> Task Monad k v
-toTask task2 fetch key = ($fetch) <$> task2 key
+-- toTask :: Task2 Monad k v -> Task Monad k v
+-- toTask task2 fetch key = ($fetch) <$> task2 key
 
-fromTask :: Task Monad k v -> Task2 Monad k v
-fromTask task key = runReaderT <$> task (\k -> ReaderT ($k)) key
-
-compose2 :: Task2 Monad k v -> Task2 Monad k v -> Task2 Monad k v
-compose2 t1 t2 key = t1 key <|> t2 key
+-- fromTask :: Task Monad k v -> Task2 Monad k v
+-- fromTask task key = runReaderT <$> task (\k -> ReaderT ($k)) key
 
 --------------------------- Task Functor: Collatz ---------------------------
 -- Collatz sequence:
 -- c[0] = n
 -- c[k] = f(c[k - 1]) where
 -- For example, if n = 12, the sequence is 3, 10, 5, 16, 8, 4, 2, 1, ...
-collatz :: Task Functor Integer Integer
-collatz fetch n | n <= 0    = Nothing
-                | otherwise = Just $ f <$> fetch (n - 1)
+collatz :: Tasks Functor Integer Integer
+collatz n | n <= 0    = Nothing
+          | otherwise = Just $ Task $ \fetch -> f <$> fetch (n - 1)
   where
     f k | even k    = k `div` 2
         | otherwise = 3 * k + 1
@@ -62,9 +50,9 @@ collatz fetch n | n <= 0    = Nothing
 -- f[k] = f[k - 1] + f[k - 2]
 -- For example, with (n, m) = (0, 1) we get usual Fibonacci sequence, and if
 -- (n, m) = (2, 1) we get Lucas sequence: 2, 1, 3, 4, 7, 11, 18, 29, 47, ...
-fibonacci :: Task Applicative Integer Integer
-fibonacci fetch n
-    | n >= 2 = Just $ (+) <$> fetch (n-1) <*> fetch (n-2)
+fibonacci :: Tasks Applicative Integer Integer
+fibonacci n
+    | n >= 2 = Just $ Task $ \fetch -> (+) <$> fetch (n-1) <*> fetch (n-2)
     | otherwise = Nothing
 
 -- Fibonacci numbers are a classic example of memoization: a non-minimal build
@@ -78,74 +66,63 @@ fibonacci fetch n
 -- a[m, n] = a[m - 1, a[m, n - 1]]
 -- Formally, it has no inputs, but we return Nothing for negative inputs.
 -- For example, a[m, 1] = 2, 3, 5, 13, 65535, ...
-ackermann :: Task Monad (Integer, Integer) Integer
-ackermann fetch (n, m)
+ackermann :: Tasks Monad (Integer, Integer) Integer
+ackermann (n, m)
     | m < 0 || n < 0 = Nothing
-    | m == 0    = Just $ pure (n + 1)
-    | n == 0    = Just $ fetch (m - 1, 1)
-    | otherwise = Just $ do index <- fetch (m, n - 1)
-                            fetch (m - 1, index)
+    | m == 0    = Just $ Task $ const $ pure (n + 1)
+    | n == 0    = Just $ Task $ \fetch -> fetch (m - 1, 1)
+    | otherwise = Just $ Task $ \fetch -> do index <- fetch (m, n - 1)
+                                             fetch (m - 1, index)
 
 -- Unlike Collatz and Fibonacci computations, the Ackermann computation cannot
 -- be statically analysed for dependencies. We can only find the first dependency
 -- statically (Ackermann m (n - 1)), but not the second one.
 
 ----------------------------- Spreadsheet examples -----------------------------
-add :: Task Applicative String Integer
-add fetch key | key /= "B1" = Nothing
-              | otherwise   = Just $ (+) <$> fetch "A1" <*> fetch "A2"
+sprsh1 :: Tasks Applicative String Integer
+sprsh1 "B1" = Just $ Task $ \fetch -> ((+)  <$> fetch "A1" <*> fetch "A2")
+sprsh1 "B2" = Just $ Task $ \fetch -> ((*2) <$> fetch "B1")
+sprsh1 _    = Nothing
 
-select :: Task Monad String Integer
-select fetch key | key /= "B1" = Nothing
-                 | otherwise   = Just $ do
-                     c1 <- fetch "C1"
-                     if c1 == 1 then fetch "A1" else fetch "A2"
+sprsh2 :: Tasks Monad String Integer
+sprsh2 "B1" = Just $ Task $ \fetch -> do c1 <- fetch "C1"
+                                         if c1 == 1 then fetch "B2"
+                                                    else fetch "A2"
+sprsh2 "B2" = Just $ Task $ \fetch -> do c1 <- fetch "C1"
+                                         if c1 == 1 then fetch "A1"
+                                                    else fetch "B1"
+sprsh2 _ = Nothing
 
-indirect :: Task Monad String Integer
-indirect fetch key | key /= "B1" = Nothing
-                   | otherwise   = Just $ do
-                       c1 <- fetch "C1"
-                       fetch ("A" ++ show c1)
+sprsh3 :: Tasks Alternative String Integer
+sprsh3 "B1" = Just $ Task $ \fetch -> (+) <$> fetch "A1" <*> (pure 1 <|> pure 2)
+sprsh3 _    = Nothing
 
-staticIF :: Bool -> Task Applicative String Int
-staticIF b fetch "B1" = Just $ if b then fetch "A1"
-                                    else (+) <$> fetch "A2" <*> fetch "A3"
-staticIF _ _     _    = Nothing
-
-sprsh1 :: Task Applicative String Integer
-sprsh1 fetch "B1" = Just ((+)  <$> fetch "A1" <*> fetch "A2")
-sprsh1 fetch "B2" = Just ((*2) <$> fetch "B1")
-sprsh1 _     _    = Nothing
-
-sprsh2 :: Task Monad String Integer
-sprsh2 fetch "B1" = Just $ do c1 <- fetch "C1"
-                              if c1 == 1 then fetch "B2"
-                                         else fetch "A2"
-sprsh2 fetch "B2" = Just $ do c1 <- fetch "C1"
-                              if c1 == 1 then fetch "A1"
-                                         else fetch "B1"
-sprsh2 _     _    = Nothing
-
-sprsh3 :: Task Alternative String Integer
-sprsh3 fetch "B1" = Just $ (+) <$> fetch "A1" <*> (pure 1 <|> pure 2)
-sprsh3 _     _    = Nothing
-
-sprsh4 :: Task MonadFail String Integer
-sprsh4 fetch "B1" = Just $ do
+sprsh4 :: Tasks MonadFail String Integer
+sprsh4 "B1" = Just $ Task $ \fetch -> do
     a1 <- fetch "A1"
     a2 <- fetch "A2"
     if a2 == 0 then fail "division by 0" else return (a1 `div` a2)
-sprsh4 _ _ = Nothing
+sprsh4 _ = Nothing
+
+indirect :: Tasks Monad String Integer
+indirect key | key /= "B1" = Nothing
+             | otherwise   = Just $ Task $ \fetch -> do c1 <- fetch "C1"
+                                                        fetch ("A" ++ show c1)
+
+staticIF :: Bool -> Tasks Applicative String Int
+staticIF b "B1" = Just $ Task $ \fetch ->
+    if b then fetch "A1" else (+) <$> fetch "A2" <*> fetch "A3"
+staticIF _ _    = Nothing
 
 fetchIO :: (Show k, Read v) => k -> IO v
 fetchIO k = do putStr (show k ++ ": "); read <$> getLine
 
 data Key = A Integer | B Integer | D Integer Integer
 
-editDistance :: Task Monad Key Integer
-editDistance _     (D i 0) = Just $ pure i
-editDistance _     (D 0 j) = Just $ pure j
-editDistance fetch (D i j) = Just $ do
+editDistance :: Tasks Monad Key Integer
+editDistance (D i 0) = Just $ Task $ const $ pure i
+editDistance (D 0 j) = Just $ Task $ const $ pure j
+editDistance (D i j) = Just $ Task $ \fetch -> do
     ai <- fetch (A i)
     bj <- fetch (B j)
     if ai == bj
@@ -155,7 +132,7 @@ editDistance fetch (D i j) = Just $ do
             delete  <- fetch (D (i - 1)  j     )
             replace <- fetch (D (i - 1) (j - 1))
             return (1 + minimum [insert, delete, replace])
-editDistance _ _ = Nothing
+editDistance _ = Nothing
 
 -- These type synonyms are not very useful, but enumerate all interesting cases.
 type FunctorialTask  k v = forall f. Functor     f => (k -> f v) -> k -> Maybe (f v)

--- a/src/Build/Task/Alternative.hs
+++ b/src/Build/Task/Alternative.hs
@@ -1,52 +1,20 @@
-{-# LANGUAGE RankNTypes #-}
-module Build.Task.Alternative (
-    failingTask, (|||), random, dependencies, transitiveDependencies, acyclic
-    ) where
+module Build.Task.Alternative (failingTask, (|||), random, dependencies) where
 
 import Control.Applicative
-import Data.Maybe
 
 import Build.Task
 import Build.Utilities
 
--- | The task that fails for any key by returning 'empty'.
+-- | The task that always fails by returning 'empty'.
 failingTask :: Task Alternative k v
-failingTask _ _ = Just empty
+failingTask = Task $ const empty
 
 -- | Run the first task then the second task, combining the results.
 (|||) :: Task Alternative k v -> Task Alternative k v -> Task Alternative k v
-(|||) task1 task2 fetch key = task1 fetch key <|> task2 fetch key
+(|||) task1 task2 = Task $ \fetch -> run task1 fetch <|> run task2 fetch
 
 random :: (Int, Int) -> Task Alternative k Int
-random (low, high) _ _ = Just $ foldr (<|>) empty $ map pure [low..high]
+random (low, high) = Task $ const $ foldr (<|>) empty $ map pure [low..high]
 
-dependencies :: Task Alternative k v -> k -> [[k]]
-dependencies task = getAltConst . sequenceA . task (\k -> AltConst [[k]])
-
-transitiveDependencies :: Eq k => Task Alternative k v -> k -> [Maybe [k]]
-transitiveDependencies task = reachM (dependencies task)
-
-acyclic :: Eq k => Task Alternative k v -> k -> Bool
-acyclic task = all isJust . transitiveDependencies task
-
--- Probably not needed
--- data Script k v a where
---     Get  :: k -> Script k v v
---     Pure :: a -> Script k v a
---     Ap   :: Script k v (a -> b) -> Script k v a -> Script k v b
---     Zero :: Script k v a
---     Plus :: Script k v a -> Script k v a -> Script k v a
-
--- instance Functor (Script k v) where
---     fmap = Ap . Pure
-
--- instance Applicative (Script k v) where
---     pure  = Pure
---     (<*>) = Ap
-
--- instance Alternative (Script k v) where
---     empty = Zero
---     (<|>) = Plus
-
--- getScript :: Task Alternative k v -> k -> Script k v (Maybe v)
--- getScript task = task Get
+dependencies :: Task Alternative k v -> [[k]]
+dependencies task = getAltConst $ run task (\k -> AltConst [[k]])

--- a/src/Build/Task/Applicative.hs
+++ b/src/Build/Task/Applicative.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE RankNTypes #-}
 module Build.Task.Applicative (
-    pureTask, dependencies, inputs, transitiveDependencies, acyclic,
-    debugPartial, partial, exceptional
+    pureTask, dependencies, inputs, partial, exceptional
     ) where
 
 import Control.Applicative
@@ -11,32 +9,16 @@ import Data.Maybe
 import Build.Task
 import Build.Utilities
 
--- | Lift a pure function to an applicative task.
-pureTask :: (k -> v) -> Task Applicative k v
-pureTask store _ = Just . pure . store
+-- | An applicative task that returns a constant.
+pureTask :: v -> Task Applicative k v
+pureTask v = Task $ const (pure v)
 
 -- TODO: Does this always terminate? It's not obvious!
-dependencies :: Task Applicative k v -> k -> [k]
-dependencies task = maybe [] getConst . task (\k -> Const [k])
+dependencies :: Task Applicative k v -> [k]
+dependencies task = getConst $ run task (\k -> Const [k])
 
-inputs :: Ord k => Task Applicative k v -> k -> [k]
-inputs task key = filter (isInput task) (reachable (dependencies task) key)
-
-transitiveDependencies :: Eq k => Task Applicative k v -> k -> Maybe [k]
-transitiveDependencies task = reach (dependencies task)
-
-acyclic :: Eq k => Task Applicative k v -> k -> Bool
-acyclic task = isJust . transitiveDependencies task
-
--- | Run a task with a partial lookup function. The result @Left k@ indicates
--- that the task failed due to a missing dependency @k@. Otherwise, the
--- result @Right (Just v)@ yields the computed value, and @Right Nothing@ is
--- returned if the given key is an input.
-debugPartial :: Applicative f => Task Applicative k v
-                            -> (k -> f (Maybe v)) -> k -> Maybe (f (Either k v))
-debugPartial task store = fmap getCompose . task (Compose . fetch)
-  where
-    fetch k = maybe (Left k) Right <$> store k
+inputs :: Ord k => Tasks Applicative k v -> k -> [k]
+inputs tasks = filter (isNothing . tasks) . reachable (maybe [] dependencies . tasks)
 
 -- | Convert a task with a total lookup function @k -> m v@ into a task
 -- with a partial lookup function @k -> m (Maybe v)@. This essentially lifts the
@@ -44,7 +26,7 @@ debugPartial task store = fmap getCompose . task (Compose . fetch)
 -- indicates that the task failed because of a missing dependency.
 -- Use 'debugPartial' if you need to know which dependency was missing.
 partial :: Task Applicative k v -> Task Applicative k (Maybe v)
-partial task fetch = fmap getCompose . task (Compose . fetch)
+partial task = Task $ \fetch -> getCompose $ run task (Compose . fetch)
 
 -- | Convert a task with a total lookup function @k -> m v@ into a task
 -- with a lookup function that can throw exceptions @k -> m (Either e v)@. This
@@ -52,4 +34,4 @@ partial task fetch = fmap getCompose . task (Compose . fetch)
 -- where the result @Left e@ indicates that the task failed because of a
 -- failed dependency lookup, and @Right v@ yeilds the value otherwise.
 exceptional :: Task Applicative k v -> Task Applicative k (Either e v)
-exceptional task fetch = fmap getCompose . task (Compose . fetch)
+exceptional task = Task $ \fetch -> getCompose $ run task (Compose . fetch)

--- a/src/Build/Task/Functor.hs
+++ b/src/Build/Task/Functor.hs
@@ -1,9 +1,8 @@
-{-# LANGUAGE RankNTypes #-}
-module Build.Task.Functor (inputTask, dependency) where
+module Build.Task.Functor (dependency) where
 
 import Data.Functor.Const
 
 import Build.Task
 
-dependency :: Task Functor k v -> k -> Maybe k
-dependency task = fmap getConst . task Const
+dependency :: Task Functor k v -> k
+dependency task = getConst $ run task Const

--- a/src/Build/Task/MonadPlus.hs
+++ b/src/Build/Task/MonadPlus.hs
@@ -1,84 +1,28 @@
-{-# LANGUAGE ConstraintKinds, FlexibleContexts, RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Build.Task.MonadPlus (
-    random, dependenciesM, transitiveDependencies, acyclic, inputs, isInput,
-    correct, pure, computeND
+    random, dependenciesM, computeND, correctBuild
     ) where
 
 import Control.Monad
 import Control.Monad.Writer
-import Data.Maybe
 
 import Build.Task
 import Build.Store
-import Build.Utilities
 
 random :: (Int, Int) -> Task MonadPlus k Int
-random (low, high) _ _ = Just $ foldr mplus mzero $ map pure [low..high]
+random (low, high) = Task $ const $ foldr mplus mzero $ map pure [low..high]
 
-dependenciesM :: MonadPlus m => Task MonadPlus k v -> (k -> m v) -> k -> m [k]
-dependenciesM task store = execWriterT . sequenceA . task fetch
+dependenciesM :: MonadPlus m => Task MonadPlus k v -> (k -> m v) -> m [k]
+dependenciesM task store = execWriterT $ run task fetch
   where
     fetch k = tell [k] >> lift (store k)
 
-transitiveDependencies :: (Eq k, MonadPlus m) => Task MonadPlus k v
-                                          -> (k -> m v) -> k -> m (Maybe [k])
-transitiveDependencies task fetch = reachM (dependenciesM task fetch)
-
-acyclic :: (Eq k, MonadPlus m) => Task MonadPlus k v -> (k -> m v) -> k -> m Bool
-acyclic task fetch = fmap isJust . transitiveDependencies task fetch
-
-inputs :: (Eq k, MonadPlus m) => Task MonadPlus k v -> (k -> m v) -> k -> m (Maybe [k])
-inputs task fetch key = do
-    deps <- transitiveDependencies task fetch key
-    return $ filter (isInput task) <$> deps
-
 -- | Run a non-deterministic task with a pure lookup function, listing all
 -- possible results, including @Nothing@ indicating that a given key is an input.
-computeND :: Task MonadPlus k v -> (k -> v) -> k -> Maybe [v]
-computeND task store = task (return . store)
+computeND :: Task MonadPlus k v -> (k -> v) -> [v]
+computeND task store = run task (return . store)
 
-correct :: Eq v => Task MonadPlus k v -> Store i k v -> Store i k v -> k -> Bool
-correct task store result k = case computeND task (flip getValue store) k of
-    Nothing -> getValue k result == getValue k store
-    Just vs -> getValue k result `elem` vs
-
--- | Given a task description @task@, a target @key@, an initial @store@, and a
--- @result@ produced by running a build system with parameters @task@, @key@ and
--- @store@, this function returns 'True' if @result@ is a correct build outcome.
--- Specifically:
--- * @result@ and @store@ must agree on the values of all inputs. In other words,
---   no inputs were corrupted during the build.
--- * @result@ is /consistent/ with the @task@, i.e. for all non-input keys, the
---   result of recomputing the @task@ matches the value stored in the @result@.
--- correctBuild :: (Eq k, Eq v) => Task Monad k v -> Store i k v -> Store i k v -> k -> Bool
--- correctBuild task store result key = all correct (reachable deps key)
---   where
---     deps    k = maybe [] snd (track task (\k -> getValue k store) k)
---     correct k = case compute task (flip getValue store) k of
---         Nothing -> getValue k result == getValue k store
---         Just v  -> getValue k result == v
-
--- pureInputs :: Eq k => Task MonadPlus k v -> (k -> v) -> k -> [Maybe [k]]
--- pureInputs task f = runIdentity . runListT . inputs task (ListT . return . pure . f)
-
--- Probably not needed
--- data Script k v a where
---     Get  :: k -> Script k v v
---     Pure :: a -> Script k v a
---     Ap   :: Script k v (a -> b) -> Script k v a -> Script k v b
---     Zero :: Script k v a
---     Plus :: Script k v a -> Script k v a -> Script k v a
-
--- instance Functor (Script k v) where
---     fmap = Ap . Pure
-
--- instance Applicative (Script k v) where
---     pure  = Pure
---     (<*>) = Ap
-
--- instance MonadPlus (Script k v) where
---     empty = Zero
---     (<|>) = Plus
-
--- getScript :: Task MonadPlus k v -> k -> Script k v (Maybe v)
--- getScript task = task Get
+correctBuild :: Eq v => Tasks MonadPlus k v -> Store i k v -> Store i k v -> k -> Bool
+correctBuild tasks store result k = case tasks k of
+    Nothing   -> getValue k result == getValue k store
+    Just task -> getValue k result `elem` computeND task (flip getValue store)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -48,17 +48,17 @@ acyclicSpreadsheet cell = case name cell of
 targets :: [Cell]
 targets = [ "A1", "A2", "A3", "B1", "B2", "B3", "C1", "C2", "F0", "F1", "F4" ]
 
-task :: Task Monad Cell Int
-task = spreadsheetTask spreadsheet
+tasks :: Tasks Monad Cell Int
+tasks = spreadsheetTask spreadsheet
 
-taskA :: Task Applicative Cell Int
-taskA = spreadsheetTaskA acyclicSpreadsheet
+tasksA :: Tasks Applicative Cell Int
+tasksA = spreadsheetTaskA acyclicSpreadsheet
 
 test :: String -> Build Monad i Cell Int -> i -> IO Bool
 test name build i = do
     let store   = inputs i
-        result  = sequentialMultiBuild build task targets store
-        correct = all (correctBuild task store result) targets
+        result  = sequentialMultiBuild build tasks targets store
+        correct = all (correctBuild tasks store result) targets
     putStr $ name ++ " is "
     case (trim name, correct) of
         ("dumb", False) -> do putStr "incorrect, which is [OK]\n"; return True
@@ -68,8 +68,8 @@ test name build i = do
 testA :: String -> Build Applicative i Cell Int -> i -> IO Bool
 testA name build i = do
     let store   = inputs i
-        result  = sequentialMultiBuildA build taskA targets store
-        correct = all (correctBuild task store result) targets
+        result  = sequentialMultiBuildA build tasksA targets store
+        correct = all (correctBuild tasks store result) targets
     putStrLn $ name ++ " is " ++ bool "incorrect: [FAIL]" "correct: [OK]" correct
     return correct
 


### PR DESCRIPTION
@ndmitchell @simonpj I have mixed feelings about this.

Here are the new types:

```haskell
type Tasks c k v = k -> Maybe (Task c k v)
newtype Task c k v = Task { run :: forall f. c f => (k -> f v) -> f v }
```

Good:

* The refactoring wasn’t too hard. 
* Some functions got simplified. For example:

    ```haskell
    -- Before
    dependencies :: Task Applicative k v -> k -> [k]
    dependencies task = maybe [] getConst . task (\k -> Const [k])

    -- After
    dependencies :: Task Applicative k v -> [k]
    dependencies task = getConst $ run task (\k -> Const [k])
    ```	

Bad:

* In many cases the simplification is somewhat misleading. For the above example, we still need to fiddle with `Maybe`, but just in a different place -- here is a snippet from `topological`:

    ```haskell
    -- Before
    deps k = dependencies task k

    -- After
    deps k = maybe [] dependencies (tasks k)
    ```
* Task descriptions became noisier. One could introduce a combinator for `Just . Task` but still this seems harder to read/understand the resulting code because of the lambda:

    ```haskell
    -- Before
    sprsh1 :: Task Applicative String Integer
    sprsh1 fetch "B1" = Just ((+)  <$> fetch "A1" <*> fetch "A2")
    sprsh1 fetch "B2" = Just ((*2) <$> fetch "B1")
    sprsh1 _     _    = Nothing
    
    -- After
    sprsh1 :: Tasks Applicative String Integer
    sprsh1 "B1" = Just $ Task $ \fetch -> ((+)  <$> fetch "A1" <*> fetch "A2")
    sprsh1 "B2" = Just $ Task $ \fetch -> ((*2) <$> fetch "B1")
    sprsh1 _    = Nothing
    ```
* Finally, and most unfortunately, I realised that we can't just pass a `Task` to Buck's `process` function and hope that it can extract transitive inputs (sources) from it: it really needs `Tasks` for this! A single `Task` only allows you to extract information about your immediate dependencies. So if we really want to be able to perform global analysis of the dependency graph in `process` we need to pass `Tasks` to it.

In summary, I'm leaning towards keeping the old abstraction. I don't think splitting into `Tasks`  and `Task` brings us much, and -- on average -- it seems to lead to less elegant code.