### PR TITLE
[WIP] A more realistic make mockup

### DIFF
--- a/src/Build/Store.hs
+++ b/src/Build/Store.hs
@@ -4,7 +4,7 @@ module Build.Store (
     Hash, Hashable (..),
 
     -- * Store
-    Store, getValue, putValue, getHash, getInfo, putInfo, mapInfo,
+    Store, values, getValue, putValue, getHash, getInfo, putInfo, mapInfo,
     initialise, agree
     ) where
 


### PR DESCRIPTION
With this implementation of make `makeT`, tasks have control over the timestamp of the outputs.
With the former implementation (`make`), they had no control over it.

This implementation allows to reproduce a forged case where make is not minimal.
Running it twice makes it rebuild already valid outputs.

It is also better because it is a `Timed v => Build () k v` build system.
The signature shows that make relies on values' own timestamps, and that make is stateless.

Not sure however if these technicalities would improve the paper. It would
certainly make it more complex if the same updates are added to the other build
systems.