### PR TITLE
Revive higher-rank polymorphism

### DIFF
--- a/build.cabal
+++ b/build.cabal
@@ -33,6 +33,7 @@ library
                         Build.Task.Monad,
                         Build.Task.MonadPlus,
                         Build.Task.Typed,
+                        Build.Task.Wrapped,
                         Build.Trace,
                         Build.Strategy,
                         Build.System,

--- a/src/Build/Algorithm.hs
+++ b/src/Build/Algorithm.hs
@@ -39,7 +39,7 @@ topological strategy tasks key = execState $ forM_ chain $ \k ->
             (newValue, newInfo) <- runStateT (newTask newFetch) info
             modify $ putInfo newInfo . updateValue k value newValue
   where
-    deps  = maybe [] (\t -> A.dependencies (A.unwrap t)) . tasks
+    deps  = maybe [] (\t -> A.dependencies $ A.unwrap t) . tasks
     chain = case topSort (graph deps key) of
         Nothing -> error "Cannot build tasks with cyclic dependencies"
         Just xs -> xs

--- a/src/Build/Algorithm.hs
+++ b/src/Build/Algorithm.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables, TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 module Build.Algorithm (
     topological,
     reordering, Chain,
@@ -12,13 +13,13 @@ import Data.Set (Set)
 
 import Build
 import Build.Task
+import Build.Task.Wrapped
 import Build.Store
 import Build.Strategy
 import Build.Utilities
 
 import qualified Data.Set as Set
 import qualified Build.Task.Applicative as A
-import qualified Build.Task.Monad as M
 
 -- Shall we skip writing to the store if the value is the same?
 -- We could skip writing if hash value == hash newValue.
@@ -32,14 +33,14 @@ topological strategy tasks key = execState $ forM_ chain $ \k ->
         Nothing   -> return ()
         Just task -> do
             value <- gets (getValue k)
-            let newTask = strategy k value (A.unwrap task)
+            let newTask = strategy k value (unwrap @Applicative task)
                 newFetch :: k -> StateT i (State (Store i k v)) v
                 newFetch = lift . gets . getValue
             info <- gets getInfo
             (newValue, newInfo) <- runStateT (newTask newFetch) info
             modify $ putInfo newInfo . updateValue k value newValue
   where
-    deps  = maybe [] (\t -> A.dependencies $ A.unwrap t) . tasks
+    deps  = maybe [] (\t -> A.dependencies $ unwrap @Applicative t) . tasks
     chain = case topSort (graph deps key) of
         Nothing -> error "Cannot build tasks with cyclic dependencies"
         Just xs -> xs
@@ -64,7 +65,7 @@ reordering strategy tasks key = execState $ do
             Just task -> do
                 value <- gets (getValue k)
                 let newTask :: Task (MonadState i) k v
-                    newTask = strategy k value (M.unwrap task)
+                    newTask = strategy k value (unwrap @Monad task)
                     newFetch :: k -> StateT i (State (Store (i, [k]) k v)) (Either k v)
                     newFetch k | k `Set.member` done = do
                                    store <- lift get
@@ -89,7 +90,7 @@ recursive strategy tasks key store = fst $ execState (fetch key) (store, [])
             done <- gets snd
             when (key `notElem` done) $ do
                 value <- gets (getValue key . fst)
-                let newTask = strategy key value (M.unwrap task)
+                let newTask = strategy key value (unwrap @Monad task)
                     newFetch :: k -> StateT i (State (Store i k v, [k])) v
                     newFetch = lift . fetch
                 info <- gets (getInfo . fst)
@@ -106,7 +107,7 @@ independent strategy tasks key store = case tasks key of
     Nothing -> store
     Just task ->
         let value   = getValue key store
-            newTask = strategy key value (M.unwrap task)
+            newTask = strategy key value (unwrap @Monad task)
             newFetch :: k -> State i v
             newFetch k = return (getValue k store)
             (newValue, newInfo) = runState (newTask newFetch) (getInfo store)

--- a/src/Build/Algorithm.hs
+++ b/src/Build/Algorithm.hs
@@ -90,8 +90,7 @@ recursive strategy tasks key store = fst $ execState (fetch key) (store, [])
             done <- gets snd
             when (key `notElem` done) $ do
                 value <- gets (getValue key . fst)
-                let newTask :: Task (MonadState i) k v
-                    newTask = strategy key value (M.clone task)
+                let newTask = strategy key value (M.clone task)
                     newFetch :: k -> StateT i (State (Store i k v, [k])) v
                     newFetch = lift . fetch
                 info <- gets (getInfo . fst)
@@ -108,7 +107,6 @@ independent strategy tasks key store = case tasks key of
     Nothing -> store
     Just task ->
         let value   = getValue key store
-            newTask :: Task (MonadState i) k v
             newTask = strategy key value (M.clone task)
             newFetch :: k -> State i v
             newFetch k = return (getValue k store)

--- a/src/Build/Algorithm.hs
+++ b/src/Build/Algorithm.hs
@@ -12,7 +12,6 @@ import Data.Set (Set)
 
 import Build
 import Build.Task
-import Build.Task.Applicative hiding (unwrap, exceptional)
 import Build.Store
 import Build.Strategy
 import Build.Utilities
@@ -40,7 +39,7 @@ topological strategy tasks key = execState $ forM_ chain $ \k ->
             (newValue, newInfo) <- runStateT (newTask newFetch) info
             modify $ putInfo newInfo . updateValue k value newValue
   where
-    deps  = maybe [] (\t -> dependencies (A.unwrap t)) . tasks
+    deps  = maybe [] (\t -> A.dependencies (A.unwrap t)) . tasks
     chain = case topSort (graph deps key) of
         Nothing -> error "Cannot build tasks with cyclic dependencies"
         Just xs -> xs

--- a/src/Build/Example/Spreadsheet.hs
+++ b/src/Build/Example/Spreadsheet.hs
@@ -81,7 +81,7 @@ type Spreadsheet = Cell -> Maybe Formula
 spreadsheetTask :: Spreadsheet -> Tasks Monad Cell Int
 spreadsheetTask spreadsheet cell@(Cell r c) = case spreadsheet cell of
     Nothing      -> Nothing -- This is an input
-    Just formula -> output $ evaluate formula
+    Just formula -> Just $ evaluate formula
   where
     evaluate formula fetch = go formula
       where go formula = case formula of
@@ -99,7 +99,7 @@ spreadsheetTask spreadsheet cell@(Cell r c) = case spreadsheet cell of
 spreadsheetTaskA :: Spreadsheet -> Tasks Applicative Cell Int
 spreadsheetTaskA spreadsheet cell@(Cell r c) = case spreadsheet cell of
     Nothing      -> Nothing -- This is an input
-    Just formula -> output $ evaluate formula
+    Just formula -> Just $ evaluate formula
   where
     evaluate formula fetch = go formula
       where go formula = case formula of

--- a/src/Build/Example/Spreadsheet.hs
+++ b/src/Build/Example/Spreadsheet.hs
@@ -81,7 +81,7 @@ type Spreadsheet = Cell -> Maybe Formula
 spreadsheetTask :: Spreadsheet -> Tasks Monad Cell Int
 spreadsheetTask spreadsheet cell@(Cell r c) = case spreadsheet cell of
     Nothing      -> Nothing -- This is an input
-    Just formula -> Just $ Task $ evaluate formula
+    Just formula -> output $ evaluate formula
   where
     evaluate formula fetch = go formula
       where go formula = case formula of
@@ -99,7 +99,7 @@ spreadsheetTask spreadsheet cell@(Cell r c) = case spreadsheet cell of
 spreadsheetTaskA :: Spreadsheet -> Tasks Applicative Cell Int
 spreadsheetTaskA spreadsheet cell@(Cell r c) = case spreadsheet cell of
     Nothing      -> Nothing -- This is an input
-    Just formula -> Just $ Task $ evaluate formula
+    Just formula -> output $ evaluate formula
   where
     evaluate formula fetch = go formula
       where go formula = case formula of

--- a/src/Build/Multi.hs
+++ b/src/Build/Multi.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 module Build.Multi (multi) where
 
 import Data.Maybe
@@ -16,7 +17,7 @@ type Partition k = k -> [k]
 multi :: Eq k => Partition k -> Tasks Applicative [k] [v] -> Tasks Applicative [k] [v]
 multi partition tasks keys
     | k:_ <- keys, partition k == keys = tasks keys
-    | otherwise = output $ \fetch ->
+    | otherwise = Just $ \fetch ->
         sequenceA [ select k <$> fetch (partition k) | k <- keys ]
   where
     select k = fromMaybe (error msg) . lookup k . zip (partition k)

--- a/src/Build/Multi.hs
+++ b/src/Build/Multi.hs
@@ -16,7 +16,7 @@ type Partition k = k -> [k]
 multi :: Eq k => Partition k -> Tasks Applicative [k] [v] -> Tasks Applicative [k] [v]
 multi partition tasks keys
     | k:_ <- keys, partition k == keys = tasks keys
-    | otherwise = Just $ Task $ \fetch ->
+    | otherwise = output $ \fetch ->
         sequenceA [ select k <$> fetch (partition k) | k <- keys ]
   where
     select k = fromMaybe (error msg) . lookup k . zip (partition k)

--- a/src/Build/SelfTracking.hs
+++ b/src/Build/SelfTracking.hs
@@ -41,7 +41,7 @@ type TaskParser c k v t = t -> Task c k v
 -- A model using Monad, works beautifully and allows storing the key on the disk
 selfTrackingM :: TaskParser Monad k v t -> Tasks Monad (Key k) (Value v t)
 selfTrackingM _      (KeyTask _) = Nothing -- Task keys are inputs
-selfTrackingM parser (Key     k) = output $ \fetch -> do
+selfTrackingM parser (Key     k) = Just $ \fetch -> do
     task <- parser <$> fetchValueTask fetch k -- Fetch and parse the task description
     Value <$> task (fetchValue fetch)
 
@@ -49,5 +49,5 @@ selfTrackingM parser (Key     k) = output $ \fetch -> do
 -- environment (e.g. a reader somewhere). Does not support cutoff if a key changes
 selfTrackingA :: TaskParser Applicative k v t -> (k -> t) -> Tasks Applicative (Key k) (Value v t)
 selfTrackingA _      _   (KeyTask _) = Nothing -- Task keys are inputs
-selfTrackingA parser ask (Key k) = output $ \fetch ->
+selfTrackingA parser ask (Key k) = Just $ \fetch ->
     fetch (KeyTask k) *> (Value <$> parser (ask k) (fetchValue fetch))

--- a/src/Build/SelfTracking.hs
+++ b/src/Build/SelfTracking.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, ScopedTypeVariables #-}
+{-# LANGUAGE ConstraintKinds, FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
 -- | This module defines 3 different strategies of self-tracking. It's all based
 -- around the idea of storing task descriptions that can be parsed into a Task.
 --
@@ -41,13 +41,13 @@ type TaskParser c k v t = t -> Task c k v
 -- A model using Monad, works beautifully and allows storing the key on the disk
 selfTrackingM :: TaskParser Monad k v t -> Tasks Monad (Key k) (Value v t)
 selfTrackingM _      (KeyTask _) = Nothing -- Task keys are inputs
-selfTrackingM parser (Key     k) = Just $ Task $ \fetch -> do
+selfTrackingM parser (Key     k) = output $ \fetch -> do
     task <- parser <$> fetchValueTask fetch k -- Fetch and parse the task description
-    Value <$> run task (fetchValue fetch)
+    Value <$> task (fetchValue fetch)
 
 -- | The Applicative model requires every key to be able to associate with its
 -- environment (e.g. a reader somewhere). Does not support cutoff if a key changes
 selfTrackingA :: TaskParser Applicative k v t -> (k -> t) -> Tasks Applicative (Key k) (Value v t)
 selfTrackingA _      _   (KeyTask _) = Nothing -- Task keys are inputs
-selfTrackingA parser ask (Key k) = Just $ Task $ \fetch ->
-    fetch (KeyTask k) *> (Value <$> run (parser $ ask k) (fetchValue fetch))
+selfTrackingA parser ask (Key k) = output $ \fetch ->
+    fetch (KeyTask k) *> (Value <$> parser (ask k) (fetchValue fetch))

--- a/src/Build/Strategy.hs
+++ b/src/Build/Strategy.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE ConstraintKinds, RankNTypes, ScopedTypeVariables #-}
 module Build.Strategy (
     Strategy, alwaysRebuildStrategy,
     makeStrategy, Time, MakeInfo,
@@ -15,7 +15,6 @@ import Build.Task
 import Build.Task.Applicative (dependencies)
 import Build.Task.Monad hiding (dependencies)
 import Build.Trace
-
 
 type Strategy c i k v = k -> v -> Task c k v -> Task (MonadState i) k v
 

--- a/src/Build/System.hs
+++ b/src/Build/System.hs
@@ -39,7 +39,7 @@ make :: forall k v. Ord k => Build Applicative (MakeInfo k) k v
 make = topological makeStrategy
 
 ninja :: (Ord k, Hashable v) => Build Applicative (VT k v) k v
-ninja = topological vtStrategyA
+ninja = topological vtStrategy
 
 type ExcelInfo k = (ApproximationInfo k, Chain k)
 
@@ -47,16 +47,16 @@ excel :: Ord k => Build Monad (ExcelInfo k) k v
 excel = reordering approximationStrategy
 
 shake :: (Eq k, Hashable v) => Build Monad (VT k v) k v
-shake = recursive vtStrategyM
+shake = recursive vtStrategy
 
 bazel :: (Ord k, Hashable v) => Build Applicative (CT k v) k v
-bazel = topological ctStrategyA
+bazel = topological ctStrategy
 
 cloudShake :: (Eq k, Hashable v) => Build Monad (CT k v) k v
-cloudShake = recursive ctStrategyM
+cloudShake = recursive ctStrategy
 
 buck :: (Hashable k, Hashable v) => Build Applicative (DCT k v) k v
-buck = topological dctStrategyA
+buck = topological dctStrategy
 
 nix :: (Hashable k, Hashable v) => Build Monad (DCT k v) k v
-nix = recursive dctStrategyM
+nix = recursive dctStrategy

--- a/src/Build/System.hs
+++ b/src/Build/System.hs
@@ -16,7 +16,6 @@ import Build
 import Build.Algorithm
 import Build.Store
 import Build.Strategy
-import Build.Task
 import Build.Trace
 
 -- Not a correct build system
@@ -30,7 +29,7 @@ busy tasks key store = execState (fetch key) store
     fetch :: k -> State (Store () k v) v
     fetch k = case tasks k of
         Nothing   -> gets (getValue k)
-        Just w -> do v <- unwrap w fetch; modify (putValue k v); return v
+        Just task -> do v <- task fetch; modify (putValue k v); return v
 
 -- Not a minimal build system, but never builds a key twice
 memo :: Eq k => Build Monad () k v

--- a/src/Build/System.hs
+++ b/src/Build/System.hs
@@ -30,7 +30,7 @@ busy tasks key store = execState (fetch key) store
     fetch :: k -> State (Store () k v) v
     fetch k = case tasks k of
         Nothing   -> gets (getValue k)
-        Just task -> do v <- run task fetch; modify (putValue k v); return v
+        Just w -> do v <- unwrap w fetch; modify (putValue k v); return v
 
 -- Not a minimal build system, but never builds a key twice
 memo :: Eq k => Build Monad () k v

--- a/src/Build/Task.hs
+++ b/src/Build/Task.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE ConstraintKinds, RankNTypes #-}
+{-# LANGUAGE ConstraintKinds, DeriveFunctor, FlexibleInstances, RankNTypes, StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 module Build.Task (
-    Task, WrappedTask (..), Tasks, output, compose, fetchIO, sprsh1, sprsh2, sprsh3
+    Task, Tasks, T (..), TT, compose, fetchIO, sprsh1, sprsh2, sprsh3
     ) where
 
 import Control.Applicative
@@ -11,14 +11,54 @@ import Control.Monad.Fail (MonadFail)
 -- | Task a value corresponding to a given key by performing necessary
 -- lookups of the dependencies using the provided lookup function. Returns
 -- @Nothing@ to indicate that a given key is an input.
-type Tasks c k v = k -> Maybe (WrappedTask c k v)
+type Tasks c k v = forall f. c f => k -> Maybe ((k -> f v) -> f v)
+type Task  c k v = forall f. c f =>             (k -> f v) -> f v
 
-newtype WrappedTask c k v = WrappedTask { unwrap :: Task c k v }
+newtype T c k v a = T { run :: forall f. c f => (k -> f v) -> f a }
 
-type Task c k v = forall f. c f => (k -> f v) -> f v
+deriving instance Functor (T Functor     k v)
+deriving instance Functor (T Applicative k v)
+deriving instance Functor (T Alternative k v)
+deriving instance Functor (T Monad       k v)
+deriving instance Functor (T MonadPlus   k v)
 
-output :: Task c k v -> Maybe (WrappedTask c k v)
-output task = Just (WrappedTask task)
+instance Applicative (T Applicative k v) where
+    pure x = T $ \_ -> pure x
+    T f <*> T x = T $ \fetch -> f fetch <*> x fetch
+
+instance Applicative (T Alternative k v) where
+    pure x = T $ \_ -> pure x
+    T f <*> T x = T $ \fetch -> f fetch <*> x fetch
+
+instance Applicative (T Monad k v) where
+    pure x = T $ \_ -> pure x
+    T f <*> T x = T $ \fetch -> f fetch <*> x fetch
+
+instance Applicative (T MonadPlus k v) where
+    pure x = T $ \_ -> pure x
+    T f <*> T x = T $ \fetch -> f fetch <*> x fetch
+
+instance Monad (T Monad k v) where
+    return x = T $ \_ -> return x
+    T x >>= f = T $ \fetch -> x fetch >>= \a -> run (f a) fetch
+
+instance Monad (T MonadPlus k v) where
+    return x = T $ \_ -> return x
+    T x >>= f = T $ \fetch -> x fetch >>= \a -> run (f a) fetch
+
+instance Alternative (T Alternative k v) where
+    empty = T $ \_ -> empty
+    T x <|> T y = T $ \fetch -> x fetch <|> y fetch
+
+instance Alternative (T MonadPlus k v) where
+    empty = T $ \_ -> empty
+    T x <|> T y = T $ \fetch -> x fetch <|> y fetch
+
+instance MonadPlus (T MonadPlus k v) where
+    mzero = empty
+    mplus = (<|>)
+
+type TT c k v = (k -> T c k v v) -> T c k v v
 
 compose :: Tasks Monad k v -> Tasks Monad k v -> Tasks Monad k v
 compose t1 t2 key = t1 key <|> t2 key
@@ -41,7 +81,7 @@ compose t1 t2 key = t1 key <|> t2 key
 -- For example, if n = 12, the sequence is 3, 10, 5, 16, 8, 4, 2, 1, ...
 collatz :: Tasks Functor Integer Integer
 collatz n | n <= 0    = Nothing
-          | otherwise = output $ \fetch -> f <$> fetch (n - 1)
+          | otherwise = Just $ \fetch -> f <$> fetch (n - 1)
   where
     f k | even k    = k `div` 2
         | otherwise = 3 * k + 1
@@ -59,7 +99,7 @@ collatz n | n <= 0    = Nothing
 -- (n, m) = (2, 1) we get Lucas sequence: 2, 1, 3, 4, 7, 11, 18, 29, 47, ...
 fibonacci :: Tasks Applicative Integer Integer
 fibonacci n
-    | n >= 2 = output $ \fetch -> (+) <$> fetch (n-1) <*> fetch (n-2)
+    | n >= 2 = Just $ \fetch -> (+) <$> fetch (n-1) <*> fetch (n-2)
     | otherwise = Nothing
 
 -- Fibonacci numbers are a classic example of memoization: a non-minimal build
@@ -76,10 +116,10 @@ fibonacci n
 ackermann :: Tasks Monad (Integer, Integer) Integer
 ackermann (n, m)
     | m < 0 || n < 0 = Nothing
-    | m == 0    = output $ const $ pure (n + 1)
-    | n == 0    = output $ \fetch -> fetch (m - 1, 1)
-    | otherwise = output $ \fetch -> do index <- fetch (m, n - 1)
-                                        fetch (m - 1, index)
+    | m == 0    = Just $ const $ pure (n + 1)
+    | n == 0    = Just $ \fetch -> fetch (m - 1, 1)
+    | otherwise = Just $ \fetch -> do index <- fetch (m, n - 1)
+                                      fetch (m - 1, index)
 
 -- Unlike Collatz and Fibonacci computations, the Ackermann computation cannot
 -- be statically analysed for dependencies. We can only find the first dependency
@@ -87,23 +127,23 @@ ackermann (n, m)
 
 ----------------------------- Spreadsheet examples -----------------------------
 sprsh1 :: Tasks Applicative String Integer
-sprsh1 "B1" = output $ \fetch -> ((+)  <$> fetch "A1" <*> fetch "A2")
-sprsh1 "B2" = output $ \fetch -> ((*2) <$> fetch "B1")
+sprsh1 "B1" = Just $ \fetch -> ((+)  <$> fetch "A1" <*> fetch "A2")
+sprsh1 "B2" = Just $ \fetch -> ((*2) <$> fetch "B1")
 sprsh1 _    = Nothing
 
 sprsh2 :: Tasks Monad String Integer
-sprsh2 "B1" = output $ \fetch -> do c1 <- fetch "C1"
-                                    if c1 == 1 then fetch "B2" else fetch "A2"
-sprsh2 "B2" = output $ \fetch -> do c1 <- fetch "C1"
-                                    if c1 == 1 then fetch "A1" else fetch "B1"
+sprsh2 "B1" = Just $ \fetch -> do c1 <- fetch "C1"
+                                  if c1 == 1 then fetch "B2" else fetch "A2"
+sprsh2 "B2" = Just $ \fetch -> do c1 <- fetch "C1"
+                                  if c1 == 1 then fetch "A1" else fetch "B1"
 sprsh2 _ = Nothing
 
 sprsh3 :: Tasks Alternative String Integer
-sprsh3 "B1" = output $ \fetch -> (+) <$> fetch "A1" <*> (pure 1 <|> pure 2)
+sprsh3 "B1" = Just $ \fetch -> (+) <$> fetch "A1" <*> (pure 1 <|> pure 2)
 sprsh3 _    = Nothing
 
 sprsh4 :: Tasks MonadFail String Integer
-sprsh4 "B1" = output $ \fetch -> do
+sprsh4 "B1" = Just $ \fetch -> do
     a1 <- fetch "A1"
     a2 <- fetch "A2"
     if a2 == 0 then fail "division by 0" else return (a1 `div` a2)
@@ -111,11 +151,11 @@ sprsh4 _ = Nothing
 
 indirect :: Tasks Monad String Integer
 indirect key | key /= "B1" = Nothing
-             | otherwise   = output $ \fetch -> do c1 <- fetch "C1"
-                                                   fetch ("A" ++ show c1)
+             | otherwise   = Just $ \fetch -> do c1 <- fetch "C1"
+                                                 fetch ("A" ++ show c1)
 
 staticIF :: Bool -> Tasks Applicative String Int
-staticIF b "B1" = output $ \fetch ->
+staticIF b "B1" = Just $ \fetch ->
     if b then fetch "A1" else (+) <$> fetch "A2" <*> fetch "A3"
 staticIF _ _    = Nothing
 
@@ -125,9 +165,9 @@ fetchIO k = do putStr (show k ++ ": "); read <$> getLine
 data Key = A Integer | B Integer | D Integer Integer
 
 editDistance :: Tasks Monad Key Integer
-editDistance (D i 0) = output $ const $ pure i
-editDistance (D 0 j) = output $ const $ pure j
-editDistance (D i j) = output $ \fetch -> do
+editDistance (D i 0) = Just $ const $ pure i
+editDistance (D 0 j) = Just $ const $ pure j
+editDistance (D i j) = Just $ \fetch -> do
     ai <- fetch (A i)
     bj <- fetch (B j)
     if ai == bj

--- a/src/Build/Task/Alternative.hs
+++ b/src/Build/Task/Alternative.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 module Build.Task.Alternative (failingTask, (|||), random, dependencies) where
 
 import Control.Applicative
@@ -7,14 +8,14 @@ import Build.Utilities
 
 -- | The task that always fails by returning 'empty'.
 failingTask :: Task Alternative k v
-failingTask = Task $ const empty
+failingTask = const empty
 
 -- | Run the first task then the second task, combining the results.
 (|||) :: Task Alternative k v -> Task Alternative k v -> Task Alternative k v
-(|||) task1 task2 = Task $ \fetch -> run task1 fetch <|> run task2 fetch
+(|||) task1 task2 fetch = task1 fetch <|> task2 fetch
 
 random :: (Int, Int) -> Task Alternative k Int
-random (low, high) = Task $ const $ foldr (<|>) empty $ map pure [low..high]
+random (low, high) = const $ foldr (<|>) empty $ map pure [low..high]
 
 dependencies :: Task Alternative k v -> [[k]]
-dependencies task = getAltConst $ run task (\k -> AltConst [[k]])
+dependencies task = getAltConst $ task (\k -> AltConst [[k]])

--- a/src/Build/Task/Applicative.hs
+++ b/src/Build/Task/Applicative.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE ConstraintKinds, DeriveFunctor, RankNTypes, ScopedTypeVariables #-}
 module Build.Task.Applicative (
     pureTask, dependencies, inputs, partial, exceptional
     ) where
@@ -6,6 +6,7 @@ module Build.Task.Applicative (
 import Control.Applicative
 import Data.Functor.Compose
 import Data.Maybe
+import Data.Proxy
 
 import Build.Task
 import Build.Utilities
@@ -13,6 +14,40 @@ import Build.Utilities
 -- | An applicative task that returns a constant.
 pureTask :: v -> Task Applicative k v
 pureTask v = Task $ const (pure v)
+
+type Ts c k v = k -> Maybe (TT c k v)
+newtype TT c k v = TT { t :: T c k v }
+type T c k v = forall f. c f => (k -> f v) -> f v
+
+tf :: T Functor Int Int
+tf fetch = (+1) <$> fetch 0
+
+ta :: T Applicative Int Int
+ta = tf
+
+ttf :: TT Functor Int Int
+ttf = TT tf
+
+tta :: TT Applicative Int Int
+tta = TT ta
+
+ds :: T Applicative k v -> [k]
+ds task = getConst $ task (\k -> Const [k])
+
+isi :: forall k v. Ts Applicative k v -> k -> Bool
+isi tasks = isNothing . tasks
+
+-- wT :: Tsc c k v -> a -> (Tc c k v -> a) -> k -> a
+-- wT tasks o i key = case tasks key of
+--     Nothing -> o
+--     Just t  -> i t
+
+is :: forall k v. Ord k => Ts Applicative k v -> k -> [k]
+is tasks = filter (isi tasks) . reachable (maybe [] d . tasks)
+  where
+    d :: TT Applicative k v -> [k]
+    d tt = ds (t tt)
+
 
 -- TODO: Does this always terminate? It's not obvious!
 dependencies :: Task Applicative k v -> [k]

--- a/src/Build/Task/Applicative.hs
+++ b/src/Build/Task/Applicative.hs
@@ -23,10 +23,10 @@ isInput :: forall k v. Tasks Applicative k v -> k -> Bool
 isInput tasks key = isNothing (tasks key :: Maybe ((k -> [v]) -> [v]))
 
 unwrap :: forall k v. Wrapped Applicative k v -> Task Applicative k v
-unwrap wrapped = runTask (wrapped f)
+unwrap wrapped = runGTask (wrapped f)
   where
-    f :: k -> ReifiedTask Applicative k v v
-    f k = ReifiedTask $ \f -> f k
+    f :: k -> GTask Applicative k v v
+    f k = GTask $ \f -> f k
 
 inputs :: forall k v. Ord k => Tasks Applicative k v -> k -> [k]
 inputs tasks = filter (isInput tasks) . reachable deps

--- a/src/Build/Task/Applicative.hs
+++ b/src/Build/Task/Applicative.hs
@@ -6,55 +6,22 @@ module Build.Task.Applicative (
 import Control.Applicative
 import Data.Functor.Compose
 import Data.Maybe
-import Data.Proxy
 
 import Build.Task
 import Build.Utilities
 
 -- | An applicative task that returns a constant.
 pureTask :: v -> Task Applicative k v
-pureTask v = Task $ const (pure v)
-
-type Ts c k v = k -> Maybe (TT c k v)
-newtype TT c k v = TT { t :: T c k v }
-type T c k v = forall f. c f => (k -> f v) -> f v
-
-tf :: T Functor Int Int
-tf fetch = (+1) <$> fetch 0
-
-ta :: T Applicative Int Int
-ta = tf
-
-ttf :: TT Functor Int Int
-ttf = TT tf
-
-tta :: TT Applicative Int Int
-tta = TT ta
-
-ds :: T Applicative k v -> [k]
-ds task = getConst $ task (\k -> Const [k])
-
-isi :: forall k v. Ts Applicative k v -> k -> Bool
-isi tasks = isNothing . tasks
-
--- wT :: Tsc c k v -> a -> (Tc c k v -> a) -> k -> a
--- wT tasks o i key = case tasks key of
---     Nothing -> o
---     Just t  -> i t
-
-is :: forall k v. Ord k => Ts Applicative k v -> k -> [k]
-is tasks = filter (isi tasks) . reachable (maybe [] d . tasks)
-  where
-    d :: TT Applicative k v -> [k]
-    d tt = ds (t tt)
-
+pureTask v = const (pure v)
 
 -- TODO: Does this always terminate? It's not obvious!
 dependencies :: Task Applicative k v -> [k]
-dependencies task = getConst $ run task (\k -> Const [k])
+dependencies task = getConst $ task (\k -> Const [k])
 
 inputs :: Ord k => Tasks Applicative k v -> k -> [k]
-inputs tasks = filter (isNothing . tasks) . reachable (maybe [] dependencies . tasks)
+inputs tasks = filter (isNothing . tasks) . reachable deps
+  where
+    deps = maybe [] (\w -> dependencies (unwrap w)) . tasks
 
 -- | Convert a task with a total lookup function @k -> m v@ into a task
 -- with a partial lookup function @k -> m (Maybe v)@. This essentially lifts the
@@ -62,7 +29,7 @@ inputs tasks = filter (isNothing . tasks) . reachable (maybe [] dependencies . t
 -- indicates that the task failed because of a missing dependency.
 -- Use 'debugPartial' if you need to know which dependency was missing.
 partial :: Task Applicative k v -> Task Applicative k (Maybe v)
-partial task = Task $ \fetch -> getCompose $ run task (Compose . fetch)
+partial task fetch = getCompose $ task (Compose . fetch)
 
 -- | Convert a task with a total lookup function @k -> m v@ into a task
 -- with a lookup function that can throw exceptions @k -> m (Either e v)@. This
@@ -70,4 +37,4 @@ partial task = Task $ \fetch -> getCompose $ run task (Compose . fetch)
 -- where the result @Left e@ indicates that the task failed because of a
 -- failed dependency lookup, and @Right v@ yeilds the value otherwise.
 exceptional :: Task Applicative k v -> Task Applicative k (Either e v)
-exceptional task = Task $ \fetch -> getCompose $ run task (Compose . fetch)
+exceptional task fetch = getCompose $ task (Compose . fetch)

--- a/src/Build/Task/Applicative.hs
+++ b/src/Build/Task/Applicative.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, DeriveFunctor, RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE ConstraintKinds, RankNTypes, ScopedTypeVariables #-}
 module Build.Task.Applicative (
     pureTask, dependencies, unwrap, inputs, partial, exceptional
     ) where
@@ -20,7 +20,7 @@ dependencies :: Task Applicative k v -> [k]
 dependencies task = getConst $ task (\k -> Const [k])
 
 isInput :: forall k v. Tasks Applicative k v -> k -> Bool
-isInput tasks key = isNothing (tasks key :: Maybe ((k -> Maybe v) -> Maybe v))
+isInput tasks key = isNothing (tasks key :: Maybe ((k -> [v]) -> [v]))
 
 unwrap :: forall k v. Wrapped Applicative k v -> Task Applicative k v
 unwrap wrapped = runTask (wrapped f)

--- a/src/Build/Task/Depend.hs
+++ b/src/Build/Task/Depend.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFunctor, RankNTypes #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module Build.Task.Depend (toDepend, Depend (..), toDepends, Depends (..)) where
 
@@ -13,7 +13,7 @@ instance Applicative (Depend k v) where
     Depend d1 f1 <*> Depend d2 f2 = Depend (d1++d2) $ \vs -> let (v1,v2) = splitAt (length d1) vs in f1 v1 $ f2 v2
 
 toDepend :: Task Applicative k v -> Depend k v v
-toDepend (Task f) = f $ \k -> Depend [k] $ \[v] -> v
+toDepend f = f $ \k -> Depend [k] $ \[v] -> v
 
 -------------------------------- Free Task Monad -------------------------------
 data Depends k v r = Depends [k] ([v] -> Depends k v r)
@@ -30,4 +30,4 @@ instance Monad (Depends k v) where
     Depends ds op >>= f = Depends ds $ \vs -> f =<< op vs
 
 toDepends :: Task Monad k v -> Depends k v v
-toDepends (Task f) = f $ \k -> Depends [k] $ \[v] -> Done v
+toDepends f = f $ \k -> Depends [k] $ \[v] -> Done v

--- a/src/Build/Task/Functor.hs
+++ b/src/Build/Task/Functor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 module Build.Task.Functor (dependency) where
 
 import Data.Functor.Const
@@ -5,4 +6,4 @@ import Data.Functor.Const
 import Build.Task
 
 dependency :: Task Functor k v -> k
-dependency task = getConst $ run task Const
+dependency task = getConst $ task Const

--- a/src/Build/Task/Monad.hs
+++ b/src/Build/Task/Monad.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
 module Build.Task.Monad (
-    dependencies, track, trackM, unwrap, inputs, correctBuild, compute, partial, exceptional
+    dependencies, track, trackM, unwrap, inputs, correctBuild, compute, partial,
+    exceptional
     ) where
 
 import Control.Monad.Trans

--- a/src/Build/Task/Monad.hs
+++ b/src/Build/Task/Monad.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
 module Build.Task.Monad (
-    dependencies, track, trackM, inputs, correctBuild, compute, partial, exceptional
+    dependencies, track, trackM, clone, inputs, correctBuild, compute, partial, exceptional
     ) where
 
 import Control.Monad.Trans
@@ -29,10 +29,19 @@ trackM task fetch = runWriterT $ task trackingFetch
     trackingFetch :: k -> WriterT [k] m v
     trackingFetch k = tell [k] >> lift (fetch k)
 
-inputs :: Ord k => Tasks Monad k v -> Store i k v -> k -> [k]
-inputs tasks store = filter (isNothing . tasks) . reachable deps
+isInput :: forall k v. Tasks Monad k v -> k -> Bool
+isInput tasks key = isNothing (tasks key :: Maybe ((k -> Maybe v) -> Maybe v))
+
+clone :: forall k v. TT Monad k v -> Task Monad k v
+clone tt fetch = run (tt f) fetch
   where
-    deps = maybe [] (\w -> snd $ track (flip getValue store) (unwrap w)) . tasks
+    f :: k -> T Monad k v v
+    f k = T $ \f -> f k
+
+inputs :: forall i k v. Ord k => Tasks Monad k v -> Store i k v -> k -> [k]
+inputs tasks store = filter (isInput tasks) . reachable deps
+  where
+    deps = maybe [] (\t -> snd $ track (flip getValue store) (clone t)) . tasks
 
 -- | Given a task description @task@, a target @key@, an initial @store@, and a
 -- @result@ produced by running a build system with parameters @task@, @key@ and
@@ -45,10 +54,10 @@ inputs tasks store = filter (isNothing . tasks) . reachable deps
 correctBuild :: (Ord k, Eq v) => Tasks Monad k v -> Store i k v -> Store i k v -> k -> Bool
 correctBuild tasks store result = all correct . reachable deps
   where
-    deps = maybe [] (\w -> snd $ track (flip getValue result) (unwrap w)) . tasks
+    deps = maybe [] (\t -> snd $ track (flip getValue result) (clone t)) . tasks
     correct k = case tasks k of
         Nothing -> getValue k result == getValue k store
-        Just w  -> getValue k result == compute (unwrap w) (flip getValue result)
+        Just t  -> getValue k result == compute (clone t) (flip getValue result)
 
 -- | Run a task with a pure lookup function. Returns @Nothing@ to indicate
 -- that a given key is an input.

--- a/src/Build/Task/Monad.hs
+++ b/src/Build/Task/Monad.hs
@@ -35,10 +35,10 @@ isInput :: forall k v. Tasks Monad k v -> k -> Bool
 isInput tasks key = isNothing (tasks key :: Maybe ((k -> Maybe v) -> Maybe v))
 
 unwrap :: forall k v. Wrapped Monad k v -> Task Monad k v
-unwrap wrapped = runTask (wrapped f)
+unwrap wrapped = runGTask (wrapped f)
   where
-    f :: k -> ReifiedTask Monad k v v
-    f k = ReifiedTask $ \f -> f k
+    f :: k -> GTask Monad k v v
+    f k = GTask $ \f -> f k
 
 inputs :: forall i k v. Ord k => Tasks Monad k v -> Store i k v -> k -> [k]
 inputs tasks store = filter (isInput tasks) . reachable deps

--- a/src/Build/Task/Monad.hs
+++ b/src/Build/Task/Monad.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
 module Build.Task.Monad (
     dependencies, track, trackM, inputs, correctBuild, compute, partial, exceptional
     ) where
@@ -16,15 +16,15 @@ import Build.Utilities
 
 -- TODO: Does this always terminate? It's not obvious!
 dependencies :: Monad m => Task Monad k v -> (k -> m v) -> m [k]
-dependencies task store = execWriterT $ run task fetch
+dependencies task store = execWriterT $ task fetch
   where
     fetch k = tell [k] >> lift (store k)
 
 track :: (k -> v) -> Task Monad k v -> (v, [k])
-track fetch task = runWriter $ run task (\k -> writer (fetch k, [k]))
+track fetch task = runWriter $ task (\k -> writer (fetch k, [k]))
 
 trackM :: forall m k v. Monad m => Task Monad k v -> (k -> m v) -> m (v, [k])
-trackM task fetch = runWriterT $ run task trackingFetch
+trackM task fetch = runWriterT $ task trackingFetch
   where
     trackingFetch :: k -> WriterT [k] m v
     trackingFetch k = tell [k] >> lift (fetch k)
@@ -32,7 +32,7 @@ trackM task fetch = runWriterT $ run task trackingFetch
 inputs :: Ord k => Tasks Monad k v -> Store i k v -> k -> [k]
 inputs tasks store = filter (isNothing . tasks) . reachable deps
   where
-    deps = maybe [] (snd . track (flip getValue store)) . tasks
+    deps = maybe [] (\w -> snd $ track (flip getValue store) (unwrap w)) . tasks
 
 -- | Given a task description @task@, a target @key@, an initial @store@, and a
 -- @result@ produced by running a build system with parameters @task@, @key@ and
@@ -45,22 +45,22 @@ inputs tasks store = filter (isNothing . tasks) . reachable deps
 correctBuild :: (Ord k, Eq v) => Tasks Monad k v -> Store i k v -> Store i k v -> k -> Bool
 correctBuild tasks store result = all correct . reachable deps
   where
-    deps = maybe [] (snd . track (flip getValue result)) . tasks
+    deps = maybe [] (\w -> snd $ track (flip getValue result) (unwrap w)) . tasks
     correct k = case tasks k of
-        Nothing   -> getValue k result == getValue k store
-        Just task -> getValue k result == compute task (flip getValue result)
+        Nothing -> getValue k result == getValue k store
+        Just w  -> getValue k result == compute (unwrap w) (flip getValue result)
 
 -- | Run a task with a pure lookup function. Returns @Nothing@ to indicate
 -- that a given key is an input.
 compute :: Task Monad k v -> (k -> v) -> v
-compute task store = runIdentity $ run task (Identity . store)
+compute task store = runIdentity $ task (Identity . store)
 
 -- | Convert a task with a total lookup function @k -> m v@ into a task
 -- with a partial lookup function @k -> m (Maybe v)@. This essentially lifts the
 -- task from the type of values @v@ to @Maybe v@, where the result @Nothing@
 -- indicates that the task failed because of a missing dependency.
 partial :: Task Monad k v -> Task Monad k (Maybe v)
-partial task = Task $ \fetch -> runMaybeT $ run task (MaybeT . fetch)
+partial task fetch = runMaybeT $ task (MaybeT . fetch)
 
 -- | Convert a task with a total lookup function @k -> m v@ into a task
 -- with a lookup function that can throw exceptions @k -> m (Either e v)@. This
@@ -68,4 +68,4 @@ partial task = Task $ \fetch -> runMaybeT $ run task (MaybeT . fetch)
 -- where the result @Left e@ indicates that the task failed because of a
 -- failed dependency lookup, and @Right v@ yeilds the value otherwise.
 exceptional :: Task Monad k v -> Task Monad k (Either e v)
-exceptional task = Task $ \fetch -> runExceptT $ run task (ExceptT . fetch)
+exceptional task fetch = runExceptT $ task (ExceptT . fetch)

--- a/src/Build/Task/MonadPlus.hs
+++ b/src/Build/Task/MonadPlus.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, RankNTypes #-}
 module Build.Task.MonadPlus (
     random, dependenciesM, computeND, correctBuild
     ) where
@@ -10,19 +10,19 @@ import Build.Task
 import Build.Store
 
 random :: (Int, Int) -> Task MonadPlus k Int
-random (low, high) = Task $ const $ foldr mplus mzero $ map pure [low..high]
+random (low, high) = const $ foldr mplus mzero $ map pure [low..high]
 
 dependenciesM :: MonadPlus m => Task MonadPlus k v -> (k -> m v) -> m [k]
-dependenciesM task store = execWriterT $ run task fetch
+dependenciesM task store = execWriterT $ task fetch
   where
-    fetch k = tell [k] >> lift (store k)
+    fetch k = tell [k] >> lift  (store k)
 
 -- | Run a non-deterministic task with a pure lookup function, listing all
 -- possible results, including @Nothing@ indicating that a given key is an input.
 computeND :: Task MonadPlus k v -> (k -> v) -> [v]
-computeND task store = run task (return . store)
+computeND task store = task (return . store)
 
 correctBuild :: Eq v => Tasks MonadPlus k v -> Store i k v -> Store i k v -> k -> Bool
 correctBuild tasks store result k = case tasks k of
-    Nothing   -> getValue k result == getValue k store
-    Just task -> getValue k result `elem` computeND task (flip getValue store)
+    Nothing -> getValue k result == getValue k store
+    Just w  -> getValue k result `elem` computeND (unwrap w) (flip getValue store)

--- a/src/Build/Task/MonadPlus.hs
+++ b/src/Build/Task/MonadPlus.hs
@@ -19,10 +19,10 @@ dependenciesM task store = execWriterT $ task fetch
     fetch k = tell [k] >> lift (store k)
 
 unwrap :: forall k v. Wrapped MonadPlus k v -> Task MonadPlus k v
-unwrap wrapped = runTask (wrapped f)
+unwrap wrapped = runGTask (wrapped f)
   where
-    f :: k -> ReifiedTask MonadPlus k v v
-    f k = ReifiedTask $ \f -> f k
+    f :: k -> GTask MonadPlus k v v
+    f k = GTask $ \f -> f k
 
 -- | Run a non-deterministic task with a pure lookup function, listing all
 -- possible results, including @Nothing@ indicating that a given key is an input.

--- a/src/Build/Task/MonadPlus.hs
+++ b/src/Build/Task/MonadPlus.hs
@@ -16,7 +16,7 @@ random (low, high) = const $ foldr mplus mzero $ map pure [low..high]
 dependenciesM :: MonadPlus m => Task MonadPlus k v -> (k -> m v) -> m [k]
 dependenciesM task store = execWriterT $ task fetch
   where
-    fetch k = tell [k] >> lift  (store k)
+    fetch k = tell [k] >> lift (store k)
 
 unwrap :: forall k v. Wrapped MonadPlus k v -> Task MonadPlus k v
 unwrap wrapped = runTask (wrapped f)

--- a/src/Build/Task/MonadPlus.hs
+++ b/src/Build/Task/MonadPlus.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE FlexibleContexts, RankNTypes, ScopedTypeVariables #-}
 module Build.Task.MonadPlus (
-    random, dependenciesM, computeND, correctBuild
+    random, dependenciesM, unwrap, computeND, correctBuild
     ) where
 
 import Control.Monad
 import Control.Monad.Writer
 
 import Build.Task
+import Build.Task.Wrapped
 import Build.Store
 
 random :: (Int, Int) -> Task MonadPlus k Int
@@ -17,18 +18,18 @@ dependenciesM task store = execWriterT $ task fetch
   where
     fetch k = tell [k] >> lift  (store k)
 
+unwrap :: forall k v. Wrapped MonadPlus k v -> Task MonadPlus k v
+unwrap wrapped = runTask (wrapped f)
+  where
+    f :: k -> ReifiedTask MonadPlus k v v
+    f k = ReifiedTask $ \f -> f k
+
 -- | Run a non-deterministic task with a pure lookup function, listing all
 -- possible results, including @Nothing@ indicating that a given key is an input.
 computeND :: Task MonadPlus k v -> (k -> v) -> [v]
 computeND task store = task (return . store)
 
-clone :: forall k v. TT MonadPlus k v -> Task MonadPlus k v
-clone tt fetch = run (tt f) fetch
-  where
-    f :: k -> T MonadPlus k v v
-    f k = T $ \f -> f k
-
 correctBuild :: Eq v => Tasks MonadPlus k v -> Store i k v -> Store i k v -> k -> Bool
 correctBuild tasks store result k = case tasks k of
     Nothing -> getValue k result == getValue k store
-    Just t -> getValue k result `elem` computeND (clone t) (flip getValue store)
+    Just t -> getValue k result `elem` computeND (unwrap t) (flip getValue store)

--- a/src/Build/Task/Wrapped.hs
+++ b/src/Build/Task/Wrapped.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE ConstraintKinds, DeriveFunctor, FlexibleInstances #-}
+{-# LANGUAGE RankNTypes, StandaloneDeriving #-}
+module Build.Task.Wrapped (ReifiedTask (..), Wrapped) where
+
+import Control.Applicative
+import Control.Monad
+
+newtype ReifiedTask c k v a =
+    ReifiedTask { runTask :: forall f. c f => (k -> f v) -> f a }
+
+type Wrapped c k v = (k -> ReifiedTask c k v v) -> ReifiedTask c k v v
+
+deriving instance Functor (ReifiedTask Functor     k v)
+deriving instance Functor (ReifiedTask Applicative k v)
+deriving instance Functor (ReifiedTask Alternative k v)
+deriving instance Functor (ReifiedTask Monad       k v)
+deriving instance Functor (ReifiedTask MonadPlus   k v)
+
+instance Applicative (ReifiedTask Applicative k v) where
+    pure x = ReifiedTask $ \_ -> pure x
+    ReifiedTask f <*> ReifiedTask x = ReifiedTask $ \fetch -> f fetch <*> x fetch
+
+instance Applicative (ReifiedTask Alternative k v) where
+    pure x = ReifiedTask $ \_ -> pure x
+    ReifiedTask f <*> ReifiedTask x = ReifiedTask $ \fetch -> f fetch <*> x fetch
+
+instance Applicative (ReifiedTask Monad k v) where
+    pure x = ReifiedTask $ \_ -> pure x
+    ReifiedTask f <*> ReifiedTask x = ReifiedTask $ \fetch -> f fetch <*> x fetch
+
+instance Applicative (ReifiedTask MonadPlus k v) where
+    pure x = ReifiedTask $ \_ -> pure x
+    ReifiedTask f <*> ReifiedTask x = ReifiedTask $ \fetch -> f fetch <*> x fetch
+
+instance Monad (ReifiedTask Monad k v) where
+    return x = ReifiedTask $ \_ -> return x
+    ReifiedTask x >>= f = ReifiedTask $ \fetch -> x fetch >>= \a -> runTask (f a) fetch
+
+instance Monad (ReifiedTask MonadPlus k v) where
+    return x = ReifiedTask $ \_ -> return x
+    ReifiedTask x >>= f = ReifiedTask $ \fetch -> x fetch >>= \a -> runTask (f a) fetch
+
+instance Alternative (ReifiedTask Alternative k v) where
+    empty = ReifiedTask $ \_ -> empty
+    ReifiedTask x <|> ReifiedTask y = ReifiedTask $ \fetch -> x fetch <|> y fetch
+
+instance Alternative (ReifiedTask MonadPlus k v) where
+    empty = ReifiedTask $ \_ -> empty
+    ReifiedTask x <|> ReifiedTask y = ReifiedTask $ \fetch -> x fetch <|> y fetch
+
+instance MonadPlus (ReifiedTask MonadPlus k v) where
+    mzero = empty
+    mplus = (<|>)

--- a/src/Build/Task/Wrapped.hs
+++ b/src/Build/Task/Wrapped.hs
@@ -5,6 +5,9 @@ module Build.Task.Wrapped (ReifiedTask (..), Wrapped) where
 import Control.Applicative
 import Control.Monad
 
+-- This whole module is just a tiresome workaround for the lack of impredicative
+-- polymorphism.
+
 newtype ReifiedTask c k v a =
     ReifiedTask { runTask :: forall f. c f => (k -> f v) -> f a }
 

--- a/src/Build/Task/Wrapped.hs
+++ b/src/Build/Task/Wrapped.hs
@@ -6,7 +6,8 @@ import Control.Applicative
 import Control.Monad
 
 -- This whole module is just a tiresome workaround for the lack of impredicative
--- polymorphism.
+-- polymorphism. If GHC adds impredicative polymorphism, we can drop it entirely
+-- and simplify the rest of the code by removing unnecessary task unwrapping.
 
 newtype ReifiedTask c k v a =
     ReifiedTask { runTask :: forall f. c f => (k -> f v) -> f a }


### PR DESCRIPTION
This PR brings back higher-rank polymorphism both for `Task` and `Tasks`:
* We can apply a monadic build system to `Tasks Applicative`.
* We can apply `trackM` to `Task Applicative`.

This allows us to get rid of mostly identical applicative and monadic variants of tracing strategies.