### PR TITLE
Run tracing functions in MonadState context

### DIFF
--- a/src/Build/Rebuilder.hs
+++ b/src/Build/Rebuilder.hs
@@ -33,7 +33,7 @@ modTimeRebuilder key value task fetch = do
     (modTime, now) <- get
     let upToDate = case Map.lookup key modTime of
             Nothing -> False
-            time -> any (\d -> Map.lookup d modTime < time) (dependencies task)
+            time -> all (\d -> Map.lookup d modTime < time) (dependencies task)
     if upToDate
     then return value
     else do

--- a/src/Build/Rebuilder.hs
+++ b/src/Build/Rebuilder.hs
@@ -68,13 +68,12 @@ approximationRebuilder key value task fetch = do
 ------------------------------- Verifying traces -------------------------------
 vtRebuilder :: (Eq k, Hashable v) => Rebuilder Monad (VT k v) k v
 vtRebuilder key value task fetch = do
-    vt <- get
-    dirty <- not <$> verifyVT key value (fmap hash . fetch) vt
+    dirty <- not <$> verifyVT key value (fmap hash . fetch)
     if not dirty
     then return value
     else do
         (newValue, deps) <- trackM task fetch
-        put =<< recordVT key newValue deps (fmap hash . fetch) =<< get
+        recordVT key newValue deps (fmap hash . fetch)
         return newValue
 
 ------------------------------- Version traces -------------------------------

--- a/src/Build/System.hs
+++ b/src/Build/System.hs
@@ -46,7 +46,7 @@ type ExcelInfo k = (ApproximationInfo k, Chain k)
 excel :: Ord k => Build Monad (ExcelInfo k) k v
 excel = reordering approximationRebuilder
 
-shake :: (Eq k, Hashable v) => Build Monad (Step, ST k v) k v
+shake :: (Eq k, Hashable v) => Build Monad (ST k v) k v
 shake = recursive stRebuilder
 
 bazel :: (Ord k, Hashable v) => Build Applicative (CT k v) k v


### PR DESCRIPTION
@ndmitchell The bug you recently spotted in traces made me realise that we might want to move `record` and `verify` functions from `Monad` to `MonadState` context. 

Not sure if that's really an improvement, so raising this PR to discuss -- what do you think?