### PR TITLE
Rewrite all functions on top of runZoom

### DIFF
--- a/build.cabal
+++ b/build.cabal
@@ -45,7 +45,7 @@ library
                         mtl              >= 2.2.1,
                         random           >= 1.1,
                         transformers     >= 0.5.2.0,
-                        lens             >= 4.17
+                        lens             >= 4.16
   default-language:     Haskell2010
   GHC-options:          -Wall
                         -fno-warn-name-shadowing

--- a/build.cabal
+++ b/build.cabal
@@ -44,7 +44,8 @@ library
                         filepath         >= 1.4.1.0,
                         mtl              >= 2.2.1,
                         random           >= 1.1,
-                        transformers     >= 0.5.2.0
+                        transformers     >= 0.5.2.0,
+                        lens             >= 4.17
   default-language:     Haskell2010
   GHC-options:          -Wall
                         -fno-warn-name-shadowing

--- a/src/Build/Store.hs
+++ b/src/Build/Store.hs
@@ -5,8 +5,11 @@ module Build.Store (
 
     -- * Store
     Store, getValue, putValue, getHash, getInfo, putInfo, mapInfo,
+    _info,
     initialise
     ) where
+
+import Control.Lens
 
 -- | A 'Hash' is used for efficient tracking and sharing of build results. We
 -- use @newtype Hash a = Hash a@ for prototyping.
@@ -58,6 +61,9 @@ getHash k = hash . getValue k
 -- | Write the build information.
 putInfo :: i -> Store i k v -> Store i k v
 putInfo i s = s { info = i }
+
+_info :: Lens' (Store i k v) i
+_info = lens getInfo (flip putInfo)
 
 -- | Modify the build information.
 mapInfo :: (i -> j) -> Store i k v -> Store j k v


### PR DESCRIPTION
Advantages:

* A single primitive `runZoom`, which can mostly be dismissed as `run` with some irrelevancy to make the `MonadState i` point at the right place. I don't envisage showing the implementation in the paper - it's not required to understand the semantics.
* There is now one `i` in `suspending` which is (by definition) correct, rather than two we have to continually try and sync up.
* The `runZoom` only appears in one place, so it wraps `run`, not wrapping and unwrapping in lots of places.
* I believe `runZoom` to be quite principled - I think it's probably `zoom` from the lens library, if you do some trick (but not sure what trick that is).
* The implementation of schedule becomes readable once more.

I'm a fan!